### PR TITLE
Document how to setup a NGINX proxy

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,8 +1,137 @@
+# General
+###################
+
+# Django debugging settings
 DEBUG_LOGGING=false
 DEBUG_TOOLBAR=false
 
-# openssl rand -hex 16
-WORKSPACE_STORAGE_ENGINE_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-# openssl rand -base64 42
-WORKSPACE_STORAGE_ENGINE_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-DB_PORT=$DB_PORT
+# Encryption settings
+SECRET_KEY='${SECRET_KEY}'
+ENCRYPTION_KEY='${ENCRYPTION_KEY}'
+
+# Email settings
+EMAIL_HOST=
+EMAIL_PORT=
+EMAIL_HOST_USER=
+EMAIL_USE_TLS=
+EMAIL_HOST_PASSWORD=
+
+# Database settings for Django
+DATABASE_PORT=$DB_PORT
+DATABASE_NAME=hexa-app
+DATABASE_USER=hexa-app
+DATABASE_PASSWORD=hexa-app
+
+# Networking
+############
+
+# To enable TLS/SSL directly on the app
+# TLS="false"
+
+# The hostname on which the services are published / bound
+BASE_HOSTNAME=localhost
+# The port number to access the backend
+BASE_PORT=8000
+# URL to use for the communication between pipelines, workers & the backend's API
+# If not set, it falls back to BASE_HOSTNAME:BASE_PORT
+INTERNAL_BASE_URL=http://app:8000
+
+# NextJS Frontend
+# If not set, it falls back to either PROXY_HOSTNAME_AND_PORT or
+# BASE_HOSTNAME:FRONTEND_PORT
+# NEW_FRONTEND_DOMAIN=http://localhost:3000
+
+# Jupyter Hub
+# If not set, it falls back to either PROXY_HOSTNAME_AND_PORT or
+# BASE_HOSTNAME:JUPYTERHUB_PORT
+# NOTEBOOKS_URL=http://localhost:8001
+
+# The port number to access the frontend
+FRONTEND_PORT=3000
+# The port number to access the Jupyter hub
+JUPYTERHUB_PORT=8001
+
+# if it's behind a reverse proxy
+# PROXY_HOSTNAME_AND_PORT=example.com
+# If TLS/SSL is set up on a reverse proxy routing to the app
+# TRUST_FORWARDED_PROTO="no"
+
+# MixPanel
+##########
+
+# mixpanel analytics
+MIXPANEL_TOKEN=
+
+# Pipelines
+############
+
+# Change this to the image of the workspace you want to use by default
+DEFAULT_WORKSPACE_IMAGE=blsq/openhexa-blsq-environment:latest
+
+# We support two spawner: docker and kubernetes. When deployed on a single
+# machine, docker is the right spawner. In that case, do not change without
+# good reasons.
+PIPELINE_SCHEDULER_SPAWNER=docker
+
+# Kubernetes resources settings (used only in kubernetes spawner mode)
+# PIPELINE_DEFAULT_CONTAINER_CPU_LIMIT=2
+# PIPELINE_DEFAULT_CONTAINER_MEMORY_LIMIT=4G
+# PIPELINE_DEFAULT_CONTAINER_CPU_REQUEST=0.05
+# PIPELINE_DEFAULT_CONTAINER_MEMORY_REQUEST=100M
+
+# Notebooks
+############
+
+# The image to run the notebook containers
+JUPYTER_IMAGE=blsq/openhexa-base-environment
+
+# Encryption settings
+JUPYTERHUB_CRYPT_KEY=${JUPYTERHUB_CRYPT_KEY}
+# Authentication settings
+HUB_API_TOKEN=${HUB_API_TOKEN}
+
+# Database settings for Jupyter Hub
+JUPYTERHUB_DATABASE_NAME=hexa-hub
+JUPYTERHUB_DATABASE_USER=hexa-hub
+JUPYTERHUB_DATABASE_PASSWORD=hexa-hub
+
+# Workspaces
+#############
+
+# Workspaces' DB settings
+WORKSPACES_DATABASE_PORT=$DB_PORT
+WORKSPACES_DATABASE_ROLE=hexa-app
+WORKSPACES_DATABASE_DEFAULT_DB=hexa-app
+WORKSPACES_DATABASE_PASSWORD=hexa-app
+
+WORKSPACE_BUCKET_PREFIX=hexa-test-
+
+# Workspace storage options
+# --------------------------
+
+# Local FS: Define the root location where the workspaces files will be stored
+# Absolute path to the directory where the workspaces data will be stored
+WORKSPACE_STORAGE_LOCATION=$WORKSPACE_STORAGE_LOCATION
+
+## GCP: Mandatory to run with GCS
+WORKSPACE_STORAGE_BACKEND_GCS_SERVICE_ACCOUNT_KEY=
+
+# # openssl rand -hex 16
+# WORKSPACE_STORAGE_ENGINE_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+# # openssl rand -base64 42
+# WORKSPACE_STORAGE_ENGINE_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+## AWS: To run it in AWS mode or in LocalHosting mode set the variable to s3
+WORKSPACE_STORAGE_BACKEND_AWS_ENDPOINT_URL=
+WORKSPACE_STORAGE_BACKEND_AWS_PUBLIC_ENDPOINT_URL=
+WORKSPACE_STORAGE_BACKEND_AWS_SECRET_ACCESS_KEY=
+WORKSPACE_STORAGE_BACKEND_AWS_ACCESS_KEY_ID=
+WORKSPACE_STORAGE_BACKEND_AWS_BUCKET_REGION=
+
+WORKSPACE_BUCKET_REGION=
+
+# Datasets
+###########
+
+# Bucket to store datasets for all workspaces
+WORKSPACE_DATASETS_BUCKET=hexa-datasets
+

--- a/compose.yml
+++ b/compose.yml
@@ -1,44 +1,40 @@
-# Defines a service that can be reused multiple times later
+# This Docker Compose manifest is dedicated to a local installation
+# of OpenHexa.
+# Do not change it without good reaons.
+
 x-app: &common
-    image: "blsq/openhexa-app:${BACKEND_VERSION:-latest}"
+    image: "blsq/openhexa-app:main"
     platform: linux/amd64
     networks:
       - openhexa
     extra_hosts:
       db: host-gateway
+    volumes:
+      - "${WORKSPACE_STORAGE_LOCATION}:/data"
+    env_file:
+      - path: ${OPENHEXA_CONF_FILE}
+        required: true
     environment:
-      - DEBUG=true
-      - DJANGO_SETTINGS_MODULE=config.settings.dev
-      - DATABASE_HOST=db
-      - DATABASE_PORT=${DB_PORT:-5432}
-      - DATABASE_NAME=hexa-app
-      - DATABASE_USER=hexa-app
-      - DATABASE_PASSWORD=hexa-app
-      - NEW_FRONTEND_DOMAIN=localhost:3000
-      - PIPELINE_SCHEDULER_SPAWNER=docker
-      - PIPELINE_API_URL=http://app:8000
-      - DEBUG_LOGGING=${DEBUG_LOGGING}
-      - DEBUG_TOOLBAR=${DEBUG_TOOLBAR}
-      - WORKSPACES_DATABASE_ROLE=hexa-app
-      - WORKSPACES_DATABASE_PASSWORD=hexa-app
-      - WORKSPACES_DATABASE_HOST=db
-      - WORKSPACES_DATABASE_PORT=${DB_PORT:-5432}
-      - WORKSPACES_DATABASE_DEFAULT_DB=hexa-app
-      - WORKSPACES_DATABASE_PROXY_HOST=db
-      - WORKSPACE_STORAGE_ENGINE_AWS_ENDPOINT_URL=http://minio:9000
-      - WORKSPACE_STORAGE_ENGINE=s3
-      - WORKSPACE_STORAGE_ENGINE_AWS_ACCESS_KEY_ID=${WORKSPACE_STORAGE_ENGINE_AWS_ACCESS_KEY_ID}
-      - WORKSPACE_STORAGE_ENGINE_AWS_SECRET_ACCESS_KEY=${WORKSPACE_STORAGE_ENGINE_AWS_SECRET_ACCESS_KEY}
-      - WORKSPACE_STORAGE_ENGINE_AWS_BUCKET_REGION=europe-west1
-      - NOTEBOOKS_HUB_URL=http://jupyterhub:8000/hub
-      - HUB_API_TOKEN=cbb352d6a412e266d7494fb014dd699373645ec8d353e00c7aa9dc79ca87800d
-      - WORKSPACE_BUCKET_PREFIX=hexa-test-
-      - WORKSPACE_BUCKET_REGION=europe-west1
-      - DEFAULT_WORKSPACE_IMAGE=blsq/openhexa-base-environment
-
+      # Internal configuration
+      ########################
+      # It allows us to run the fixture command
+      DEBUG: true
+      # The Python module where Django can find its settings
+      DJANGO_SETTINGS_MODULE: config.settings.local
+      # The URI to access the Jupyter Hub through the local Docker network
+      NOTEBOOKS_HUB_URL: http://jupyterhub:8000/hub
+      # The URL passed to the pipelines to access the backend API through the
+      # local Docker network.
+      PIPELINE_API_URL: http://app:8000
+      # The hostname to access the database. It corresponds to an added extra
+      # host that is the Docker gateway (see above).
+      DATABASE_HOST: db
+      WORKSPACES_DATABASE_HOST: db
+      WORKSPACES_DATABASE_PROXY_HOST: db
+      # To control what hostname can access the backend
+      ADDITIONAL_ALLOWED_HOSTS: "app,frontend"
 services:
   app:
-    # Inherit from the block defined on top and override some fields
     <<: *common
     command: "manage runserver 0:8000"
     restart: unless-stopped
@@ -53,15 +49,21 @@ services:
       retries: 3
   
   frontend:
-    image: "blsq/openhexa-frontend:${FRONTEND_VERSION:-main}"
+    image: "blsq/openhexa-frontend:main"
     platform: linux/amd64
     networks:
       - openhexa
     container_name: frontend
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
+    env_file:
+      - path: ${OPENHEXA_CONF_FILE}
+        required: true
     environment:
-      - OPENHEXA_BACKEND_URL=http://app:8000
+      # Internal configuration
+      ########################
+      # The URL to access the backend through the local Docker network
+      OPENHEXA_BACKEND_URL: http://app:8000
     profiles:
       - frontend
     restart: unless-stopped
@@ -91,10 +93,6 @@ services:
 
   pipelines_scheduler:
     <<: *common
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: pipelines
     command: "manage pipelines_scheduler"
     restart: unless-stopped
     profiles:
@@ -106,27 +104,6 @@ services:
       start_period: "15s"
       retries: 3
 
-  minio:
-    image: quay.io/minio/minio
-    command: server --address 0.0.0.0:9000 --console-address ":9001" /data
-    volumes:
-      - minio_data:/data
-    profiles:
-      - minio
-    ports:
-      - "${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
-    networks:
-      - openhexa
-    environment:
-      - MINIO_ROOT_USER=${WORKSPACE_STORAGE_ENGINE_AWS_ACCESS_KEY_ID}
-      - MINIO_ROOT_PASSWORD=${WORKSPACE_STORAGE_ENGINE_AWS_SECRET_ACCESS_KEY}
-    healthcheck:
-      test: mc ready local || exit 1
-      interval: 30s
-      timeout: 20s
-      retries: 3
-
   jupyter:
     image: blsq/openhexa-base-environment
     platform: linux/amd64
@@ -136,27 +113,43 @@ services:
 
   jupyterhub:
     platform: linux/amd64
-    image: blsq/openhexa-jupyterhub:local-2024.04.18-1
+    image: blsq/openhexa-jupyterhub:local-2024.09.19
     command: ["jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_dev_config.py"]
     container_name: jupyterhub
     networks:
       - openhexa
     profiles:
       - notebook
+    env_file:
+      - path: ${OPENHEXA_CONF_FILE}
+        required: true
     environment:
-      LOAD_DEV_CONFIG: "true"
-      JUPYTER_IMAGE: blsq/openhexa-base-environment
+      # Internal configuration
+      ########################
+      # The name of the local Docker network to join
       DOCKER_NETWORK_NAME: openhexa
+      # The hostname where to access the Jupyter Hub service on the local Docker
+      # network
       HUB_IP: jupyterhub
-      HUB_DB_URL: postgresql://hexa-hub:hexa-hub@host.docker.internal:${DB_PORT:-5432}/hexa-hub
+      # The URI of the database dedicated to the Jupyter Hub
+      HUB_DB_URL: postgresql://${JUPYTERHUB_DATABASE_USER:-hexa-hub}:${JUPYTERHUB_DATABASE_PASSWORD:-hexa-hub}@host.docker.internal:${DATABASE_PORT:-5432}/${JUPYTERHUB_DATABASE_NAME:-hexa-hub}
+      # The URI to authenticate by the backend through the local Docker network
       AUTHENTICATION_URL: http://app:8000/notebooks/authenticate/
+      # The URI to get the default credentials by the backend through the local
+      # Docker network
       DEFAULT_CREDENTIALS_URL: http://app:8000/notebooks/default-credentials/
+      # The URI to get the workspace credentials by the backend through the
+      # local Docker network
       WORKSPACE_CREDENTIALS_URL: http://app:8000/workspaces/credentials/
+      # The URL to log out by the backend through the local Docker network
       LOGOUT_REDIRECT_URL: http://app:8000/
+      # The URL to access the backend through the local Docker network
       HEXA_SERVER_URL: http://app:8000/
-      CONTENT_SECURITY_POLICY: "frame-ancestors 'self' localhost:*"
-      JUPYTERHUB_CRYPT_KEY: 0b9c2791baa0b19e10f1dc9c4a1a702dda0a37c332378870e9542271a365b9b8
-      HUB_API_TOKEN: cbb352d6a412e266d7494fb014dd699373645ec8d353e00c7aa9dc79ca87800d
+      # Make sure that we load the settings to run locally
+      LOAD_DEV_CONFIG: "true"
+      # Networking
+      ############
+      CONTENT_SECURITY_POLICY: "frame-ancestors 'self' ${PUBLIC_HOSTNAME:-localhost}:*"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -174,7 +167,3 @@ services:
 networks:
   openhexa:
     name: openhexa
-volumes:
-  pgdata:
-  minio_data:
-

--- a/debian/openhexa.service
+++ b/debian/openhexa.service
@@ -11,6 +11,8 @@ RemainAfterExit=true
 WorkingDirectory=/etc/openhexa
 ExecStart=/usr/share/openhexa/openhexa.sh -g start
 ExecStop=/usr/share/openhexa/openhexa.sh -g stop
+User=openhexa
+Group=openhexa
 
 [Install]
 WantedBy=multi-user.target

--- a/script/openhexa.sh
+++ b/script/openhexa.sh
@@ -28,6 +28,7 @@ function usage() {
   stop      stops all services
   status    reports current status
   ps        reports running services
+  config    reports the config used
   update    pulls last container images
   prepare   runs database migrations and installs fixtures
   logs      gets all the logs
@@ -82,6 +83,7 @@ function is_backend_reachable() {
 }
 
 function is_db_accepting_connexion() {
+  # TODO replace with get_config_or_default
   load_env
   pg_isready -p "${DB_PORT}" >/dev/null 2>&1
   return 0
@@ -142,6 +144,10 @@ function execute() {
       exit_code=1
     fi
     exit_properly $exit_code
+    ;;
+  config)
+    run_compose_with_profiles config
+    exit_properly 0
     ;;
   ps)
     run_compose_with_profiles ps


### PR DESCRIPTION
Here the instructions.

It correctly routes and rewrites the requests to the frontend and jupyterhub (including for its websocket). However, I still have an error when running a pipeline in the frontend:

```
[Network error]: TypeError: fetch failed. Backend is unreachable. Is it running?
 ⨯ ApolloError: fetch failed
    at new ApolloError (/code/node_modules/@apollo/client/errors/errors.cjs:33:28)
    at /code/node_modules/@apollo/client/core/core.cjs:2014:78
    at both (/code/node_modules/@apollo/client/utilities/utilities.cjs:1353:31)
    at /code/node_modules/@apollo/client/utilities/utilities.cjs:1344:72
    at new Promise (<anonymous>)
    at Object.then (/code/node_modules/@apollo/client/utilities/utilities.cjs:1344:24)
    at Object.error (/code/node_modules/@apollo/client/utilities/utilities.cjs:1355:49)
    at notifySubscription (/code/node_modules/zen-observable/lib/Observable.js:140:18)
    at onNotify (/code/node_modules/zen-observable/lib/Observable.js:179:3)
    at SubscriptionObserver.error (/code/node_modules/zen-observable/lib/Observable.js:240:7) {
  graphQLErrors: [],
  protocolErrors: [],
  clientErrors: [],
  networkError: TypeError: fetch failed
      at node:internal/deps/undici/undici:13178:13
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
    [cause]: Error: connect ECONNREFUSED 172.18.0.4:8000
        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1607:16)
        at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17) {
      errno: -111,
      code: 'ECONNREFUSED',
      syscall: 'connect',
      address: '172.18.0.4',
      port: 8000
    }
  },
  extraInfo: undefined
}
[Network error]: TypeError: fetch failed. Backend is unreachable. Is it running?
 ⨯ ApolloError: fetch failed
    at new ApolloError (/code/node_modules/@apollo/client/errors/errors.cjs:33:28)
    at /code/node_modules/@apollo/client/core/core.cjs:2014:78
    at both (/code/node_modules/@apollo/client/utilities/utilities.cjs:1353:31)
    at /code/node_modules/@apollo/client/utilities/utilities.cjs:1344:72
    at new Promise (<anonymous>)
    at Object.then (/code/node_modules/@apollo/client/utilities/utilities.cjs:1344:24)
    at Object.error (/code/node_modules/@apollo/client/utilities/utilities.cjs:1355:49)
    at notifySubscription (/code/node_modules/zen-observable/lib/Observable.js:140:18)
    at onNotify (/code/node_modules/zen-observable/lib/Observable.js:179:3)
    at SubscriptionObserver.error (/code/node_modules/zen-observable/lib/Observable.js:240:7) {
  graphQLErrors: [],
  protocolErrors: [],
  clientErrors: [],
  networkError: TypeError: fetch failed
      at node:internal/deps/undici/undici:13178:13
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
    [cause]: Error: connect ECONNREFUSED 172.18.0.4:8000
        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1607:16)
        at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17) {
      errno: -111,
      code: 'ECONNREFUSED',
      syscall: 'connect',
      address: '172.18.0.4',
      port: 8000
    }
  },
  extraInfo: undefined
}
Error tracking event:  [TypeError: fetch failed] {
  cause:  [Error: connect ECONNREFUSED 172.18.0.4:8000] {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '172.18.0.4',
  port: 8000
}
}
```

It seems that it can't reach the pipelines runner, when for the rest it doesn't have any issue.

When checking its container status, it's reported as unhealthy. The Python process is indeed `<defunct>`.

it seems that it crashes after we request to run the pipeline. As I don't have much more logs than that, I don't know where to look at:

```
wait-for-it: waiting 15 seconds for db:5433
wait-for-it: db:5433 is available after 0 seconds
start pipeline runner
Run pipeline: 39b8e3cc-81f0-4fde-bdd8-ea8fae57c8f1
End of run pipeline: 39b8e3cc-81f0-4fde-bdd8-ea8fae57c8f1
```
