### PR TITLE
Add 2 commands to backup and restore from the script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 test-results/
 .secrets
 openhexa.nginx
+backup.conf*
+backup/
+workspaces-*

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Quick Start
 Requirements:
 - a least [Docker 26.1](https://docs.docker.com/engine/install/debian/#install-using-the-repository)
 - Debian bookworm
-- Debian packages `gettext-base`, `postgresql` (14+), `postgresql-<postgresql version>-postgis-3`
+- Debian packages `gettext-base`, `postgresql` (14+), `postgresql-<postgresql version>-postgis-3`, `duplicity` (optional to manage backup and restore)
 - [yq](https://github.com/mikefarah/yq/#install)
 
 After having cloned this repo and change your current dir to it, you can check
@@ -171,6 +171,10 @@ sudo apt update
 sudo apt install openhexa
 ```
 
+If you want to manage backup and retore through our script, you can install it
+with recommended packages `sudo apt install --install-recommends openhexa`.
+
+
 If you have Systemd, OpenHexa is run as a Systemd service `openhexa` (that you
 can then manage with `systemctl`). If you don't use Systemd, you can still run
 the service by running `/usr/share/openhexa/openhexa -g start`.
@@ -224,6 +228,37 @@ During the setup, the following is done on the PostgreSQL side:
   with encrypted password authentication.
 - authorize `hexa-hub` to connect to `hexa-hub` from the entier Docker
   subnetwork with encrypted password authentication.
+
+##### Backup
+
+You can manage your backup and restore directly with OpenHexa. It will backup
+all the workspaces data, and all databases. This relies on the tool `duplicity`.
+Make sure that it is installed if you haven't installed it yet (if you install
+OpenHexa with `apt`, do it with the recommended packages).
+
+First, you need to set it up:
+
+```bash
+/usr/share/openhexa/setup.sh backup /mylocaldirecotry/where/to/do/thebackup/ encryption_passkey
+```
+
+Then you can back up the data with:
+
+```bash
+/usr/share/openhexa/openhexa.sh backup
+```
+
+Depending on the user activities, it might be a good idea to stop the service or
+simply redirect the website to a maintenance HTML page.
+
+To restore the data, you execute the following:
+
+```bash
+/usr/share/openhexa/openhexa.sh backup
+```
+
+In this case, we advise you to stop the service before performing a full
+restore.
 
 #### Configuration properties
 

--- a/script/common_functions.sh
+++ b/script/common_functions.sh
@@ -2,12 +2,17 @@
 
 COMPOSE_FILE_PATH="compose.yml"
 CONFIG_FILE_PATH=".env"
+BACKUP_CONFIG_FILE_PATH="backup.conf"
 WORKSPACE_DATA_DIRECTORY="workspaces"
 
 SUDO_COMMAND="sudo"
 
 function dot_env_file() {
   echo "${CONFIG_FILE_PATH}"
+}
+
+function backup_conf_file() {
+  echo "${BACKUP_CONFIG_FILE_PATH}"
 }
 
 function load_env() {
@@ -19,6 +24,7 @@ function setup() {
   if [[ $OPTION_GLOBAL == "on" ]]; then
     COMPOSE_FILE_PATH="/usr/share/openhexa/compose.yml"
     CONFIG_FILE_PATH="/etc/openhexa/env.conf"
+    BACKUP_CONFIG_FILE_PATH="/etc/openhexa/backup.conf"
     WORKSPACE_DATA_DIRECTORY="/var/lib/openhexa/workspaces"
   fi
   if ((UID == 0)); then
@@ -42,6 +48,17 @@ function dist_dot_env_file() {
     current_env_file=".env.dist"
   fi
   echo "$current_env_file"
+}
+
+function get_backup_config() {
+  local variable_name=$1
+  local backup_file
+  if [[ -r "$(backup_conf_file)" ]] && backup_file=$(backup_conf_file); then
+    (
+      source "${backup_file}"
+      echo "${!variable_name}"
+    )
+  fi
 }
 
 function get_config_or_default() {
@@ -101,7 +118,11 @@ function parse_commandline() {
     esac
   done
   shift $((OPTIND - 1))
-  [[ -n $1 ]] && COMMAND="$1"
+  [[ -n $1 ]] && {
+    COMMAND="$1"
+    shift
+    COMMAND_PARAMETERS="$@"
+  }
 }
 
 function exit_properly() {


### PR DESCRIPTION
This requires duplicity that is a standard package.

File servers supported: local file system and SFTP.

Example of usage:

```
❯ ./script/setup.sh backup sftp://foo:pass@localhost:2222/upload mypassphrase -f 10
Setup backup:
- file server location: sftp://foo:pass@localhost:2222/
- file server type detected: sftp
- maximum period of incremental backup is 10 days
- copy the existing backup config file `backup.conf.bck-2024-10-23T17:10:56+02:00`
- generate the config file OK
❯ ./script/openhexa.sh backup
Prepare dump of the whole PostgreSQL cluster dedicated to OpenHexa ... OK
Load backup configuration ... OK
Back up workspace files and PostgreSQL dump ... Local and Remote metadata are synchronized, no sync needed.
Last full backup date: Wed Oct 23 16:41:40 2024
--------------[ Backup Statistics ]--------------
StartTime 1729696210.55 (Wed Oct 23 17:10:10 2024)
EndTime 1729696210.56 (Wed Oct 23 17:10:10 2024)
ElapsedTime 0.01 (0.01 seconds)
SourceFiles 2
SourceFileSize 8544 (8.34 KB)
NewFiles 1
NewFileSize 4096 (4.00 KB)
DeletedFiles 0
ChangedFiles 1
ChangedFileSize 4448 (4.34 KB)
ChangedDeltaSize 0 (0 bytes)
DeltaEntries 2
RawDeltaSize 9 (9 bytes)
TotalDestinationSizeChange 246 (246 bytes)
Errors 0
-------------------------------------------------

OK
Remove DB cluster dump ... OK
❯ ./script/openhexa.sh restore
Keep a copy of the target ...OK
Restore workspace files ... Local and Remote metadata are synchronized, no sync needed.
Last full backup date: Wed Oct 23 16:41:40 2024
OK
Restore PostgreSQL dump ...OK
```

todo:

* [x] update README