### PR TITLE
Bump openhexa-app and openhexa-frontend

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@
 # Do not change it without good reaons.
 
 x-app: &common
-    image: "blsq/openhexa-app:0.74.11"
+    image: "blsq/openhexa-app:1.2.4"
     platform: linux/amd64
     networks:
       - openhexa
@@ -49,7 +49,7 @@ services:
       retries: 3
   
   frontend:
-    image: "blsq/openhexa-frontend:0.54.4"
+    image: "blsq/openhexa-frontend:1.2.4"
     platform: linux/amd64
     networks:
       - openhexa

--- a/compose.yml
+++ b/compose.yml
@@ -105,7 +105,7 @@ services:
       retries: 3
 
   jupyter:
-    image: ${DEFAULT_WORKSPACE_IMAGE:-blsq/openhexa-base-environment:1.4.5}
+    image: ${DEFAULT_WORKSPACE_IMAGE:-blsq/openhexa-base-environment:1.9.0}
     platform: linux/amd64
     command: echo
     profiles:
@@ -113,7 +113,7 @@ services:
 
   jupyterhub:
     platform: linux/amd64
-    image: blsq/openhexa-jupyterhub:local-2024.11.15
+    image: blsq/openhexa-jupyterhub:2025.04.09
     command: ["jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_dev_config.py"]
     container_name: jupyterhub
     networks:


### PR DESCRIPTION
use 1.2.4 based current production versions.

@qgerome should we also upgrade 
 - blsq/openhexa-base-environment:1.4.5
 - blsq/openhexa-jupyterhub:local-2024.11.15

