### PR TITLE
fix: Remove "all" setup task to enforce env setup first...

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,22 @@ your installation by running first
 It'll tell you that the `.env` is missing, that is expected as it's the next
 step.
 
-Then, you need to setup the environment and the database. To do so execute the
-following command
+Then, generate the configuration file:
 
 ```bash
-./script/setup.sh all
+./script/setup.sh env
 ```
 
-This will generate a file in the working directory: `.env` (ee below to
-know more about the configuration properties).
+This will generate a file in the working directory: `.env` (see below to
+know more about the configuration properties). Review it and adjust settings
+such as database passwords before continuing.
+
+Then, set up the PostgreSQL database (cluster, users, and databases using
+values from your `.env`):
+
+```bash
+./script/setup.sh db
+```
 
 Then you can prepare the database and environment with
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,7 +4,8 @@ set -e
 
 case "$1" in
 configure)
-  /usr/share/openhexa/setup.sh -g all
+  /usr/share/openhexa/setup.sh -g env
+  /usr/share/openhexa/setup.sh -g db
 
   /usr/share/openhexa/openhexa.sh -g update
   /usr/share/openhexa/openhexa.sh -g prepare

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -32,7 +32,6 @@ function usage() {
 
     COMMANDS:
 
-    all       sets up all: first the PostgreSQL database, then the environment
     env       sets up the environment and stores it in a file (requires an
               existing PostgreSQL cluster named \`openhexa\`)
     db        sets up the PostgreSQL database
@@ -380,9 +379,8 @@ function setup_env() {
   echo "Setup environment:"
 
   if ! does_postgresql_cluster_openhexa_exist >/dev/null 2>&1; then
-    echo "The PostgreSQL cluster for OpenHexa hasn't been created."
-    echo "Please first run \`$0 db\` or \`$0 all\`."
-    return 1
+    prompt_sudo_password_if_needed
+    ensure_db_cluster || return 1
   fi
 
   db_port=$(get_postgresql_port_for_cluster_openhexa)
@@ -420,15 +418,12 @@ function create_pgsql_cluster() {
   $SUDO_COMMAND pg_createcluster "${PGSQL_VERSION}" "${PGSQL_CLUSTER}" --start >/dev/null 2>&1
 }
 
-function setup_db() {
-  local db_port
-  echo "Setup database:"
-
+function ensure_db_cluster() {
   echo -n "- create cluster if it does not exists ... "
   if ! does_postgresql_cluster_openhexa_exist; then
     create_pgsql_cluster
     echo "created"
-    
+
     echo -n "- make the cluster listening on the Docker network ... "
     listen_on_docker_network
     echo "done"
@@ -440,14 +435,6 @@ function setup_db() {
     echo -n "- restart the cluster to take in account new setup ... "
     restart_postgreql
     echo "done"
-
-    echo -n "- create users and databases for the Open Hexa app and Jupyter Hub ... "
-    db_port=$(get_postgresql_port_for_cluster_openhexa)
-    create_postgresql_user "${db_port}" "$(get_config_or_default DATABASE_USER)" "$(get_config_or_default DATABASE_PASSWORD)"
-    create_postgresql_db "${db_port}" "$(get_config_or_default DATABASE_NAME)" "$(get_config_or_default DATABASE_USER)"
-    create_postgresql_user "${db_port}" "$(get_config_or_default JUPYTERHUB_DATABASE_USER)" "$(get_config_or_default JUPYTERHUB_DATABASE_PASSWORD)"
-    create_postgresql_db "${db_port}" "$(get_config_or_default JUPYTERHUB_DATABASE_NAME)" "$(get_config_or_default JUPYTERHUB_DATABASE_USER)"
-    echo "done"
   else
     echo "already created"
   fi
@@ -457,6 +444,21 @@ function setup_db() {
     restart_postgreql
   fi
   echo "running"
+}
+
+function setup_db() {
+  local db_port
+  echo "Setup database:"
+
+  ensure_db_cluster || return 1
+
+  echo -n "- create users and databases for the Open Hexa app and Jupyter Hub ... "
+  db_port=$(get_postgresql_port_for_cluster_openhexa)
+  create_postgresql_user "${db_port}" "$(get_config_or_default DATABASE_USER)" "$(get_config_or_default DATABASE_PASSWORD)"
+  create_postgresql_db "${db_port}" "$(get_config_or_default DATABASE_NAME)" "$(get_config_or_default DATABASE_USER)"
+  create_postgresql_user "${db_port}" "$(get_config_or_default JUPYTERHUB_DATABASE_USER)" "$(get_config_or_default JUPYTERHUB_DATABASE_PASSWORD)"
+  create_postgresql_db "${db_port}" "$(get_config_or_default JUPYTERHUB_DATABASE_NAME)" "$(get_config_or_default JUPYTERHUB_DATABASE_USER)"
+  echo "done"
 }
 
 function remove_user_and_group() {
@@ -681,12 +683,6 @@ function execute() {
   local command=$1
   local exit_code=0
   case "${command}" in
-  all)
-    prompt_sudo_password_if_needed
-    setup_db || exit_properly 1
-    setup_env || exit_properly 1
-    exit_properly 0
-    ;;
   env)
     setup_env
     exit_properly 0


### PR DESCRIPTION
_before_ creating DB users. This way we can make sure the user edits the passwords, instead of creating them with default.

**WIP, TODO:**
- [ ] Remove default passwords from `.env.dist`