### PR TITLE
 Update to OH 5.10.1 and a bunch of improvements (HEXA-1552)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -218,13 +218,3 @@ LOGFIRE_SEND_TO_LOGFIRE=false
 OAUTH2_ACCESS_TOKEN_EXPIRE_SECONDS=3600
 # Comma-separated list of hosts allowed as OAuth2 redirect URIs.
 OAUTH2_ALLOWED_REDIRECT_URI_HOSTS=
-
-# JWT Workspace Tokens (optional)
-#################################
-# Required only for the `issueWorkspaceToken` GraphQL mutation. Generate a key
-# with: openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
-# OPENHEXA_JWT_PRIVATE_KEY=
-# OPENHEXA_JWT_KID=
-# OPENHEXA_JWT_ISSUER=https://app.openhexa.org
-# OPENHEXA_JWT_AUDIENCE=openhexa-clients
-# OPENHEXA_JWT_TTL=3600

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Finally, you can run openhexa with
 ./script/openhexa.sh start
 ```
 
+> [!IMPORTANT]
+> The first thing you'll want to do on your running instance is go to the Django admin (on `/admin`). There you can create an "organization" and give your superuser membership to it.
+
 To stop, execute
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -523,6 +523,12 @@ server {
         proxy_buffering off;
     }
 
+    # Static Webapps auth-token endpoint is served by the backend (app),
+    # not the frontend, so route it directly to the backend port.
+    location /webapps/ {
+        proxy_pass http://localhost:8000;
+    }
+
 
     location / {
         proxy_pass http://localhost:3000;
@@ -544,6 +550,7 @@ You need to update on OpenHexa config in `/etc/openhexa/env.conf`:
 TRUST_FORWARDED_PROTO="false"
 PROXY_HOSTNAME_AND_PORT=example.com
 INTERNAL_BASE_URL=http://app:8000
+APP_PORT=8000
 FRONTEND_PORT=3000
 JUPYTERHUB_PORT=8001
 ```
@@ -610,6 +617,12 @@ server {
         proxy_buffering off;
     }
 
+    # Static Webapps auth-token endpoint is served by the backend (app),
+    # not the frontend, so route it directly to the backend port.
+    location /webapps/ {
+        proxy_pass http://localhost:8000;
+    }
+
 
     location / {
         proxy_pass http://localhost:3000;
@@ -624,6 +637,7 @@ and in `/etc/openhexa/env.conf`
 TRUST_FORWARDED_PROTO="true"
 PROXY_HOSTNAME_AND_PORT=example.com
 INTERNAL_BASE_URL=http://app:8000
+APP_PORT=8000
 FRONTEND_PORT=3000
 JUPYTERHUB_PORT=8001
 ```

--- a/README.md
+++ b/README.md
@@ -297,11 +297,11 @@ simply redirect the website to a maintenance HTML page.
 
 Once configured, the following commands are available:
 
-| Command | Description |
-| --- | --- |
-| `/usr/share/openhexa/openhexa.sh backup` | Back up the PostgreSQL cluster, workspace files, Forgejo data and `.env` snapshot. |
+| Command                                         | Description                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `/usr/share/openhexa/openhexa.sh backup`        | Back up the PostgreSQL cluster, workspace files, Forgejo data and `.env` snapshot.       |
 | `/usr/share/openhexa/openhexa.sh backup-status` | Show the duplicity `collection-status` for both the `workspaces` and `forgejo` backends. |
-| `/usr/share/openhexa/openhexa.sh restore` | Restore the latest backup. This requires stopping the services before a full restore. |
+| `/usr/share/openhexa/openhexa.sh restore`       | Restore the latest backup. This requires stopping the services before a full restore.    |
 
 After a restore, an `openhexa-env.bak` file is left next to the workspace data:
 compare it with the live `.env` to make sure `ENCRYPTION_KEY`, `SECRET_KEY` and
@@ -423,35 +423,17 @@ webapps on the main backend host.
 For custom-domain webapps, list each domain in `ADDITIONAL_ALLOWED_HOSTS`
 _and_ attach it to the corresponding Webapp via the Django admin.
 
-#### Upgrading from 4.6.0
+#### Upgrading an existing installation
 
-The 5.x series introduces Forgejo as a hard dependency. To upgrade an
-existing 4.6.0 installation:
+Upgrading an existing installation may require manual steps such as adding new environment
+variables, infrastructure changes, and one-off migration commands.
+These are documented per version, newest first, in [UPGRADING.md](./UPGRADING.md).
 
-```bash
-sudo systemctl stop openhexa
-sudo apt update && sudo apt install --only-upgrade openhexa
-# Pull the new app/frontend images and the Forgejo image:
-sudo /usr/share/openhexa/openhexa.sh -g update
-# Run migrations and bootstrap the Git server admin user:
-sudo /usr/share/openhexa/openhexa.sh -g prepare
-sudo systemctl start openhexa
-```
-
-The package post-install hook runs `update` and `prepare` automatically when
-installing for the first time, but on upgrades you should re-run them
-explicitly to apply Django migrations introduced between 4.6.0 and 5.6.2
-(custom webapp domains, AI agent tables, scheduled-run version selection,
-read-only table protection).
-
-The new `GIT_SERVER_ADMIN_PASSWORD` is generated only when `.env` does not
-yet exist. On an in-place upgrade, your existing `.env` will not contain
-this variable and you should add these env variables manually:
-
-```bash
-GIT_SERVER_ADMIN_USERNAME=openhexa-admin
-GIT_SERVER_ADMIN_PASSWORD=something-secure
-```
+> [!IMPORTANT]
+> `setup.sh` only generates `.env` on a **fresh** install, so new variables
+> added to `.env.dist` are not propagated to an existing `.env`. Always check
+> [UPGRADING.md](./UPGRADING.md) for the variables introduced since your
+> installed version before starting the upgraded stack.
 
 #### Test
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,22 @@ server {
     }
 
 }
+
+# Support for webapps wildcard host:
+# Route all *.webapps.example.com subdomains (e.g. my-app.webapps.example.com) to the backend on port 8000.
+server {
+    listen 80;
+    client_max_body_size 500M;
+    server_name *.webapps.example.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
 ```
 
 Enable and check it:
@@ -614,6 +630,32 @@ server {
         proxy_pass http://localhost:3000;
     }
 
+}
+
+# Support for webapps wildcard host:
+# Route all *.webapps.example.com subdomains (e.g. my-app.webapps.example.com) to the backend on port 8000.
+server {
+    client_max_body_size 500M;
+    server_name *.webapps.example.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    listen 443 ssl;
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+}
+
+
+server {
+    listen 80;
+    server_name *.webapps.example.com;
+    return 301 https://$host$request_uri;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ The versions are described into the [changelog file](debian/changelog). The last
 one is unreleased and is the one that is published. To manage versions and
 changelog, we use the debhelper tool `dch`.
 
+**Version convention:** the package **upstream version equals the OpenHEXA
+app/frontend release it ships** (e.g. `5.10.1`), and must match the
+`blsq/openhexa-app` / `blsq/openhexa-frontend` tags in `compose.yml`.
+
 To add a new change, do:
 
 ```bash
@@ -169,7 +173,7 @@ working copy, and all your stage need to be clean. So, if you have any changes,
 commit or stash them before running the script.
 
 The resulting package is available in the parent directory:
-`../openhexa_1.0-1_amd64.deb`.
+`../openhexa_5.10.1-1_amd64.deb`.
 
 #### Install
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,19 @@ The package post-install hook runs `update` and `prepare` automatically on a
 **fresh** install. On an **upgrade** you should re-run them explicitly to
 apply the Django migrations introduced since your installed version.
 
+### Checking for new environment variables
+
+New releases sometimes add environment variables. `update` runs an automatic
+check and warns you when your `.env` is missing keys that exist in `.env.dist`.
+You can run the check on demand:
+
+```bash
+# Report keys present in .env.dist but missing from your .env:
+sudo /usr/share/openhexa/openhexa.sh -g env-check
+# Or check an env file at a non-standard location:
+sudo /usr/share/openhexa/openhexa.sh -g env-check /path/to/.env
+```
+
 ---
 
 ## 5.x

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,93 @@
+# Upgrading existing OpenHEXA installs
+
+This document lists the manual steps required to move an **existing**
+OpenHEXA installation from one version to the next: new environment
+variables, breaking changes, and one-off migration commands.
+
+## General upgrade procedure
+
+```bash
+sudo systemctl stop openhexa
+sudo apt update && sudo apt install --only-upgrade openhexa
+# Pull the new app/frontend images (and any new possible images):
+sudo /usr/share/openhexa/openhexa.sh -g update
+# Apply Django migrations and bootstrap any new services:
+sudo /usr/share/openhexa/openhexa.sh -g prepare
+sudo systemctl start openhexa
+```
+
+The package post-install hook runs `update` and `prepare` automatically on a
+**fresh** install. On an **upgrade** you should re-run them explicitly to
+apply the Django migrations introduced since your installed version.
+
+---
+
+## 5.x
+
+OpenHEXA 5.x introduces Forgejo as a hard dependency (it backs the Static Webapps feature).
+
+### New environment variables
+
+Append the variables you are missing to your `.env` (the defaults in this list match
+`.env.dist`).
+
+```bash
+# Forgejo Git server (required since 5.0.0, backs Static Webapps)
+GIT_SERVER_ADMIN_USERNAME=openhexa-admin
+GIT_SERVER_ADMIN_PASSWORD=something-secure   # set this yourself on upgrade
+
+# Absolute path to the directory where Forgejo persists its data
+# (SQLite metadata DB, git repositories, attachments, app.ini, ...).
+FORGEJO_STORAGE_LOCATION=$FORGEJO_STORAGE_LOCATION
+
+# Static Webapps
+# Parent domain to serve webapps from a subdomain; leave empty to disable.
+WEBAPPS_DOMAIN=
+# Comma-separated custom domains attached to public webapps.
+ADDITIONAL_ALLOWED_HOSTS=
+
+# Workspace storage: new S3 backend (optional)
+# IAM role to assume for short-lived notebook credentials.
+WORKSPACE_STORAGE_BACKEND_AWS_ROLE_ARN=
+
+# Datasets: max files snapshotted per dataset version (previews)
+WORKSPACE_DATASETS_FILE_SNAPSHOT_SIZE=50
+
+# AI assistant: monthly request cap per workspace
+ASSISTANT_MONTHLY_LIMIT=200
+# Optional Pydantic Logfire integration for AI agent observability
+LOGFIRE_SEND_TO_LOGFIRE=false
+
+# OAuth2
+OAUTH2_ACCESS_TOKEN_EXPIRE_SECONDS=3600
+# Comma-separated hosts allowed as OAuth2 redirect URIs.
+OAUTH2_ALLOWED_REDIRECT_URI_HOSTS=
+
+# Allow users to sign up without an invitation
+ALLOW_SELF_REGISTRATION=false
+```
+
+### Breaking changes
+
+- **Forgejo Git server** is now required. The package ships a `forgejo`
+  service (image `codeberg.org/forgejo/forgejo:14`) backed by the
+  `forgejo_data` volume, listening on host port `3100`. The Django backend
+  reaches it over the internal Docker network at `http://forgejo:3000` (set in
+  `compose.yml`, no configuration needed).
+- **App service command** changed from `manage runserver` to `start`
+  (gunicorn + `UvicornWorkerNoLifespan`). Required for Server Sent Events.
+  details and the AI agent loop.
+- **Backup/restore layout** changed: data is split into
+  `<LOCATION>/workspaces` and `<LOCATION>/forgejo`, and backups now also
+  capture `FORGEJO_STORAGE_LOCATION` and a snapshot of `.env`. Pre-upgrade
+  backups remain readable by pointing `duplicity restore` at the old path; new
+  backups start a fresh full at the new sub-prefix. See the
+  [Backup section in the README](./README.md#backup) for the legacy-restore
+  procedure.
+
+### Manual steps
+
+Run `openhexa.sh prepare` after upgrading to apply the Django migrations
+introduced across the 5.x series (custom webapp domains, AI agent tables,
+scheduled-run version selection, read-only table protection) and to bootstrap
+the Forgejo admin user.

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,7 @@
 # Do not change it without good reaons.
 
 x-app: &common
-    image: "blsq/openhexa-app:5.6.2"
+    image: "blsq/openhexa-app:5.10.1"
     platform: linux/amd64
     networks:
       - openhexa
@@ -59,7 +59,7 @@ services:
       retries: 3
 
   frontend:
-    image: "blsq/openhexa-frontend:5.6.2"
+    image: "blsq/openhexa-frontend:5.10.1"
     platform: linux/amd64
     networks:
       - openhexa

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,10 @@ openhexa (5.10.1-1) stable; urgency=medium
   * Add UPGRADING.md documenting per-version manual upgrade steps (new
     environment variables, breaking changes, migration commands). See
     UPGRADING.md before upgrading an existing installation.
+  * Add `openhexa.sh env-check [ENV_FILE]` to diff your `.env` against
+    `.env.dist` and report keys missing after an upgrade. It runs
+    automatically at the start of `update`, so the post-install hook warns
+    about new variables without reading the docs.
 
  -- Bram Jans <bjans@bluesquarehub.com>  Tue, 23 Jun 2026 14:15:00 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,9 @@
-openhexa (4.0-2) stable; urgency=medium
+openhexa (5.10.1-1) stable; urgency=medium
 
   [ Bram Jans ]
   * Update OpenHEXA to version 5.10.1
+  * Align the Debian package version with the OpenHEXA app/frontend version
+    it ships. This to avoid confusion about the version numbering.
   * Improved documentation for webapps Nginx config
   * Add UPGRADING.md documenting per-version manual upgrade steps (new
     environment variables, breaking changes, migration commands). See

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+openhexa (4.0-2) stable; urgency=medium
+
+  [ Bram Jans ]
+  * Update OpenHEXA to version 5.10.1
+  * Improved documentation for webapps Nginx config
+  * Improved `.env.dist` to more easily see changes on version upgrades
+
+ -- Bram Jans <bjans@bluesquarehub.com>  Tue, 23 Jun 2026 14:15:00 +0200
+
 openhexa (4.0-1) stable; urgency=medium
 
   [ Bram Jans ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,9 @@ openhexa (4.0-2) stable; urgency=medium
   [ Bram Jans ]
   * Update OpenHEXA to version 5.10.1
   * Improved documentation for webapps Nginx config
-  * Improved `.env.dist` to more easily see changes on version upgrades
+  * Add UPGRADING.md documenting per-version manual upgrade steps (new
+    environment variables, breaking changes, migration commands). See
+    UPGRADING.md before upgrading an existing installation.
 
  -- Bram Jans <bjans@bluesquarehub.com>  Tue, 23 Jun 2026 14:15:00 +0200
 

--- a/script/openhexa.sh
+++ b/script/openhexa.sh
@@ -31,6 +31,8 @@ function usage() {
     ps          reports running services
     config      reports the config used
     update      pulls last container images
+    env-check   reports keys in .env.dist missing from your .env
+                (optionally pass a path to the .env file to check)
     prepare     runs databases migrations and installs fixtures
     logs        gets all the logs
     backup         backs up OpenHexa
@@ -43,6 +45,21 @@ function usage() {
   fi
   local cmd=$1
   case $cmd in
+  env-check)
+    echo """
+
+    Usage:    env-check [ENV_FILE]
+
+    Diffs the keys defined in .env.dist against your .env and reports the
+    keys that are missing (added in newer versions) as well as keys
+    present in your .env but no longer in .env.dist.
+
+    ARGUMENTS:
+
+    ENV_FILE  path to the env file to check; defaults to the standard
+              location when omitted
+    """
+    ;;
   restore)
     echo """
 
@@ -343,6 +360,61 @@ function perform_restore() {
   )
 }
 
+function extract_env_keys() {
+  # Print the (uncommented) variable names defined in an env file, sorted and
+  # deduplicated. Commented examples (`# FOO=bar`) are intentionally ignored.
+  local file=$1
+  grep -E '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=' "${file}" |
+    sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*/\1/' |
+    sort -u
+}
+
+function perform_env_check() {
+  local env_file dist_file missing extra
+  # Optionally check an arbitrary env file; the real one may live elsewhere
+  # or be named differently.
+  env_file=${1:-$(dot_env_file)}
+  dist_file=$(dist_dot_env_file)
+
+  if [[ ! -r $dist_file ]]; then
+    echo "Reference file ${dist_file} not found; cannot check the environment."
+    return 1
+  fi
+  if [[ ! -r $env_file ]]; then
+    echo "No environment file at ${env_file}; nothing to check."
+    echo "Run \`setup.sh env\` (or \`setup.sh all\`) to create it first."
+    return 1
+  fi
+
+  missing=$(comm -23 <(extract_env_keys "${dist_file}") <(extract_env_keys "${env_file}"))
+  extra=$(comm -13 <(extract_env_keys "${dist_file}") <(extract_env_keys "${env_file}"))
+
+  if [[ -z $missing ]]; then
+    echo "Your ${env_file} has every key from ${dist_file}."
+  else
+    echo "Missing in your ${env_file} (added in newer versions):"
+    while IFS= read -r key; do
+      [[ -n $key ]] && echo "  ${key}"
+    done <<<"${missing}"
+  fi
+
+  if [[ -n $extra ]]; then
+    echo
+    echo "Present in your ${env_file} but not in ${dist_file} (possibly removed/renamed):"
+    while IFS= read -r key; do
+      [[ -n $key ]] && echo "  ${key}"
+    done <<<"${extra}"
+  fi
+
+  if [[ -n $missing ]]; then
+    echo
+    echo "Add the missing keys to ${env_file}; the defaults are documented in ${dist_file}."
+    echo "Refer to the UPGRADING.md for guidance."
+    return 1
+  fi
+  return 0
+}
+
 function execute() {
   local command=$1
   local exit_code=0
@@ -411,8 +483,15 @@ function execute() {
     exit_properly 0
     ;;
   update)
+    # Warn (don't block) if the .env is missing keys added in newer versions.
+    perform_env_check || true
+    echo
     run_compose_with_profiles --profile spawned-notebook pull --policy always
     exit_properly 0
+    ;;
+  env-check)
+    perform_env_check "$COMMAND_PARAMETERS"
+    exit_properly $?
     ;;
   prepare)
     run_compose_with_profiles run app fixtures --localhosting


### PR DESCRIPTION
* Update OpenHEXA to version `5.10.1`
* Align the Debian package version with the OpenHEXA app/frontend version it ships. This to avoid confusion about the version numbering.
* Improved documentation for webapps Nginx config
* Add UPGRADING.md documenting per-version manual upgrade steps (new environment variables, breaking changes, migration commands).  I chose to go this route instead of re-organizing `.env.dist`, I'd like to keep logical groupings there.
* Add `openhexa.sh env-check [ENV_FILE]` to diff your `.env` against `.env.dist` and report keys missing after an upgrade. ( runs automatically at the start of `update`, so the post-install hook warns about new variables without reading the docs)
    ```bash
    # example run
    $ ./script/openhexa.sh env-check .envlocal                                                                                                                                                                                              09:22:28
    Missing in your .envlocal (added in newer versions):
      ADDITIONAL_ALLOWED_HOSTS
      ALLOW_SELF_REGISTRATION
      ASSISTANT_MONTHLY_LIMIT
      DJANGO_SUPERUSER_EMAIL
      DJANGO_SUPERUSER_PASSWORD
      DJANGO_SUPERUSER_USERNAME
      FORGEJO_STORAGE_LOCATION
      GIT_SERVER_ADMIN_PASSWORD
      GIT_SERVER_ADMIN_USERNAME
      LOGFIRE_SEND_TO_LOGFIRE
      OAUTH2_ACCESS_TOKEN_EXPIRE_SECONDS
      OAUTH2_ALLOWED_REDIRECT_URI_HOSTS
      OVERRIDE_WORKSPACES_DATABASE_HOST
      STORAGE_BACKEND
      WEBAPPS_DOMAIN
      WORKSPACE_DATASETS_FILE_SNAPSHOT_SIZE
      WORKSPACE_STORAGE_BACKEND_AWS_ROLE_ARN
    
    Add the missing keys to .envlocal; the defaults are documented in .env.dist.
    Refer to the UPGRADING.md for guidance.
    ```
* Cleanup: remove unneeded ENV vars from `.env.dist`